### PR TITLE
Add responsive styling and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,40 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AI Tools for Academic Skills & Assessment</title>
-  <style>
-    body {
-      font-family: system-ui, sans-serif;
-      background: #f9f9f9;
-      margin: 0;
-      padding: 20px;
-      line-height: 1.6;
-      color: #333;
-    }
-    h1 {
-      text-align: center;
-      color: #1a1a1a;
-    }
-    .tool {
-      background: white;
-      border-radius: 8px;
-      padding: 20px;
-      margin: 20px auto;
-      max-width: 800px;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    }
-    a {
-      color: #0066cc;
-    }
-    code {
-      background: #eee;
-      padding: 2px 6px;
-      border-radius: 4px;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 
+<button id="theme-toggle" aria-label="Toggle dark mode">Toggle dark mode</button>
+
 <h1>AI Tools to Support Graduate Capabilities</h1>
+<p class="codex-info">This GitHub page is also an example of interacting with Codex. Codex is an AI agent that reads instructions from users and automatically updates code.</p>
 
 <div class="tool">
   <h2>Microsoft 365 Copilot</h2>
@@ -161,5 +135,6 @@
   </p>
 </div>
 
+<script src="scripts/main.js"></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,1 +1,20 @@
-// Optional JavaScript
+// Toggle dark mode based on user preference and button click
+function setInitialTheme() {
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (prefersDark) {
+    document.body.classList.add('dark-mode');
+  }
+}
+
+function setupToggle() {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setInitialTheme();
+  setupToggle();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,73 @@
+:root {
+  --bg-color: #f9f9f9;
+  --text-color: #333;
+  --heading-color: #1a1a1a;
+  --tool-bg: #ffffff;
+  --link-color: #0066cc;
+  --code-bg: #eee;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: var(--bg-color);
+  margin: 0;
+  padding: 20px;
+  line-height: 1.6;
+  color: var(--text-color);
+  transition: background 0.3s, color 0.3s;
+}
+
+h1 {
+  text-align: center;
+  color: var(--heading-color);
+}
+
+.tool {
+  background: var(--tool-bg);
+  border-radius: 8px;
+  padding: 20px;
+  margin: 20px auto;
+  max-width: 800px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+a {
+  color: var(--link-color);
+}
+
+code {
+  background: var(--code-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+  --bg-color: #1a1a1a;
+  --text-color: #f9f9f9;
+  --heading-color: #ffffff;
+  --tool-bg: #333333;
+  --link-color: #4da3ff;
+  --code-bg: #555555;
+}
+
+#theme-toggle {
+  display: block;
+  margin: 0 auto 20px auto;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  background: var(--link-color);
+  color: #fff;
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 10px;
+  }
+  .tool {
+    padding: 15px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- move CSS to a standalone `style.css`
- add a dark mode theme and a toggle button
- make layout more mobile friendly
- mention Codex on the page
- wire up a small script to toggle dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686955c149f4832291e05ac194e5828d