### PR TITLE
Fix burger menu icon visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -57,6 +57,7 @@ nav {
   border: none;
   font-size: 24px;
   cursor: pointer;
+  color: var(--text-color);
 }
 
 a {


### PR DESCRIPTION
## Summary
- make the menu toggle inherit the text color so it's visible in dark mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68696d4e331c83228e793d2a31b9d990